### PR TITLE
Cosmetic improvements to contracts.

### DIFF
--- a/functional-lib/data/applicative.rkt
+++ b/functional-lib/data/applicative.rkt
@@ -11,9 +11,9 @@
                      syntax/parse))
 
 (provide gen:applicative applicative? applicative/c
+         pure/c
          (rename-out [delayed-pure pure]
-                     [delayed-pure? pure?]
-                     [delayed-pure/c pure/c]))
+                     [delayed-pure? pure?]))
 
 (require racket/trace)
 
@@ -79,5 +79,8 @@
   [(define (chain f x)
      (f (delayed-pure-value x)))])
 
-(define (delayed-pure/c ctc)
-  (struct/c delayed-pure ctc))
+(define/subexpression-pos-prop (pure/c ctc)
+  (let ([ctc (coerce-contract 'pure/c ctc)])
+    (rename-contract
+     (struct/c delayed-pure ctc)
+     (build-compound-type-name 'pure/c ctc))))

--- a/functional-lib/data/either.rkt
+++ b/functional-lib/data/either.rkt
@@ -46,9 +46,13 @@
   #:methods gen:monad
   [(define (chain f x) x)])
 
-(define (either/c failure/c success/c)
-  (or/c (struct/c failure failure/c)
-        (struct/c success success/c)))
+(define/subexpression-pos-prop (either/c failure/c success/c)
+  (let ([failure/c (coerce-contract 'either/c failure/c)]
+        [success/c (coerce-contract 'either/c success/c)])
+    (rename-contract
+     (or/c (struct/c failure failure/c)
+           (struct/c success success/c))
+     (build-compound-type-name 'either/c failure/c success/c))))
 
 (define/match (either g f m)
   [(_ f (success x)) (f x)]

--- a/functional-lib/data/maybe.rkt
+++ b/functional-lib/data/maybe.rkt
@@ -73,8 +73,11 @@
 
 (define nothing? #{eq? nothing})
 
-(define (maybe/c val/c)
-  (or/c nothing? (struct/c just val/c)))
+(define/subexpression-pos-prop (maybe/c val/c)
+  (let ([val/c (coerce-contract 'maybe/c val/c)])
+    (rename-contract
+     (or/c nothing? (struct/c just val/c))
+     (build-compound-type-name 'maybe/c val/c))))
 
 (define/match (maybe x f m)
   [(_ f (just x))  (f x)]


### PR DESCRIPTION
Make `pure/c`, `either/c`, and `maybe/c` cooperate with Check Syntax
and use pretty names.