### PR TITLE
`either` example: Change `just` to `success`

### DIFF
--- a/functional-doc/scribblings/data/functional.scrbl
+++ b/functional-doc/scribblings/data/functional.scrbl
@@ -651,12 +651,12 @@ using @tech{either}.
   (define (safe-first lst)
     (if (empty? lst)
         (failure "attempted to get the first element of an empty list")
-        (just (first lst))))
+        (success (first lst))))
 
   (define (safe-rest lst)
      (if (empty? lst)
          (failure "attempted to get the rest of an empty list")
-         (just (rest lst))))
+         (success (rest lst))))
 
   (define (divide-first-two lst)
     (do [a  <- (safe-first lst)]


### PR DESCRIPTION
In the "we can rewrite the safe- functions from the maybe section using either" example, it seems that two uses of `just` should have been changed to `success`.

(If it really should be `just` -- or if (no pun intended) either `just` or `success` is fine -- then maybe a code comment or margin-note could explain?)