### PR TITLE
Applicative-apply should return an applicative

### DIFF
--- a/functional-doc/scribblings/data/functional.scrbl
+++ b/functional-doc/scribblings/data/functional.scrbl
@@ -171,7 +171,7 @@ guarantee about what it is, so you should always ignore it completely.
 
 Implementing the @racket[apply] method is somewhat more straightforward. It should be a function of
 two arguments, this first corresponding to the functor in application position and second a list of
-functors provided as arguments in the application.
+functors provided as arguments in the application. It shoud produce an applicative functor result.
 
 Here is an example implementation of the most trivial possible applicative functor, the identity
 functor:
@@ -187,7 +187,7 @@ functor:
     [(define (pure _ x)
        (id x))
      (define (apply f xs)
-       (base:apply (id-val f) (base:map id-val xs)))])
+       (id (base:apply (id-val f) (base:map id-val xs))))])
   ((id +) (pure 2) (pure 3)))
 
 @subsection[#:tag "monads"]{Monads}
@@ -352,7 +352,7 @@ Here is an example implementation of the most trivial possible monad, the identi
     [(define (pure _ x)
        (id x))
      (define (apply f xs)
-       (base:apply (id-val f) (base:map id-val xs)))]
+       (id (base:apply (id-val f) (base:map id-val xs))))]
     #:methods gen:monad
     [(define (chain f x)
        (f (id-val x)))])

--- a/functional-doc/scribblings/data/functional.scrbl
+++ b/functional-doc/scribblings/data/functional.scrbl
@@ -171,7 +171,7 @@ guarantee about what it is, so you should always ignore it completely.
 
 Implementing the @racket[apply] method is somewhat more straightforward. It should be a function of
 two arguments, this first corresponding to the functor in application position and second a list of
-functors provided as arguments in the application. It shoud produce an applicative functor result.
+functors provided as arguments in the application. It should produce an applicative functor result.
 
 Here is an example implementation of the most trivial possible applicative functor, the identity
 functor:


### PR DESCRIPTION
In particular, the examples for the `id` applicative and monad should return `id` instances from `apply`.

```racket
(define (apply f xs)
  (id (base:apply (id-val f) (base:map id-val xs))))
```