### PR TITLE
Use functor map implementation for sequences when applicable

### DIFF
--- a/functional-lib/data/functor.rkt
+++ b/functional-lib/data/functor.rkt
@@ -14,6 +14,7 @@
   ([c:sequence? (define map c:map)]))
 
 (define/renamed map (variadic-map f . args)
-  (if (c:sequence? (first args))
+  (if (and (c:sequence? (first args))
+           (not (empty? (rest args))))
       (apply c:map f args)
       (apply map f args)))

--- a/functional-test/tests/data/functor.rkt
+++ b/functional-test/tests/data/functor.rkt
@@ -1,7 +1,9 @@
 #lang racket/base
 
 (require (except-in data/collection map)
+         (prefix-in b: racket/base)
          data/functor
+         racket/generic
          rackunit
          rackunit/spec)
 
@@ -15,7 +17,33 @@
   (describe "map"
     (it "applies a function to the values inside a context"
       (check-equal? (map add1 (identity 25))
-                    (identity 26)))
+                    (identity 26))
+      (check-equal? (sequence->list (map add1 (list 1 2 3)))
+                    (list 2 3 4)))
 
     (it "works like zip when applied to sequences"
-      (check-equal? (sequence->list (map + '(1 2 3) '(10 20 30))) '(11 22 33)))))
+        (check-equal? (sequence->list (map + '(1 2 3) '(10 20 30))) '(11 22 33)))
+
+    (it "uses a functor map specification, if available, when applied to a sequence"
+        (struct bag (items)
+          #:transparent
+
+          #:methods gen:functor
+          [(define (map f x)
+             ;; exclude numbers too big to fit in the bag
+             (bag (b:filter (lambda (v)
+                              (< v 10))
+                            (b:map f (bag-items x)))))]
+
+          #:methods gen:sequence
+          [(define/generic -empty? empty?)
+           (define/generic -first first)
+           (define/generic -rest rest)
+           (define (empty? x)
+             (-empty? (bag-items x)))
+           (define (first x)
+             (-first (bag-items x)))
+           (define (rest x)
+             (bag (-rest (bag-items x))))])
+
+        (check-equal? (map add1 (bag (list 7 8 9))) (bag (list 8 9))))))


### PR DESCRIPTION
Fixes #11.

At the moment, it looks like `map` delegates sequence input to the `data/collection` version of `map` in order to leverage the "zip" behavior when more than one sequence input is provided, in which case the functor implementation would be inapplicable in any case. This fix modifies that condition to specifically check for the presence of more than one input sequence before delegating. Otherwise, it uses the functor implementation, including for the case of a lone sequence.
